### PR TITLE
backend: reset player word banks on game start

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -74,6 +74,10 @@ io.on('connection', socket => {
 
   socket.on('start_game', () => {
     initializeDeck();
+    // Reset all players' word banks
+    for (const playerId in gameState.players) {
+      gameState.players[playerId].words = [];
+    }
     io.emit('game_state_update', gameState);
   });
 


### PR DESCRIPTION
- Clear individual player word arrays when starting a new game
- Ensure clean slate for each player at game initialization


fixes #6 