### PR TITLE
Prevent stealing words with the same root

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.18.2",
-        "socket.io": "^4.7.4"
+        "socket.io": "^4.7.4",
+        "wink-lemmatizer": "^3.0.4"
       },
       "devDependencies": {
         "nodemon": "^3.1.0"
@@ -1451,6 +1452,28 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/wink-lemmatizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/wink-lemmatizer/-/wink-lemmatizer-3.0.4.tgz",
+      "integrity": "sha512-EdLJfy1xLF2ze2cp9Z3qiEWjiq+V8ZVRWiWooCXTXR0AyPxY8ezm4E0puJ0yIj5szzED9tcXV2U7RboaGvboFw==",
+      "license": "MIT",
+      "dependencies": {
+        "wink-lexicon": "^2.2.0",
+        "wink-porter2-stemmer": "^2.0.0"
+      }
+    },
+    "node_modules/wink-lexicon": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/wink-lexicon/-/wink-lexicon-2.2.0.tgz",
+      "integrity": "sha512-QIuHS9r/HV6q3PCCz6pymg4gbsryW9wDk8CHdU+sDn0kJcHpECNDIcdY0Q/mZpqxtFLp9dzIw7pjcStLBbGZGg==",
+      "license": "MIT"
+    },
+    "node_modules/wink-porter2-stemmer": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/wink-porter2-stemmer/-/wink-porter2-stemmer-2.0.1.tgz",
+      "integrity": "sha512-0g+RkkqhRXFmSpJQStVXW5N/WsshWpJXsoDRW7DwVkGI2uDT6IBCoq3xdH5p6IHLaC6ygk7RWUsUx4alKxoagQ==",
+      "license": "MIT"
     },
     "node_modules/ws": {
       "version": "8.17.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,8 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.18.2",
-    "socket.io": "^4.7.4"
+    "socket.io": "^4.7.4",
+    "wink-lemmatizer": "^3.0.4"
   },
   "devDependencies": {
     "nodemon": "^3.1.0"

--- a/backend/utils/gameLogic.js
+++ b/backend/utils/gameLogic.js
@@ -71,9 +71,6 @@ function sharesSameRoot(word1, word2) {
     lemmatizer.adjective(word2.toLowerCase()),
   ];
 
-  console.log(`Word1 "${word1}" forms:`, word1Forms);
-  console.log(`Word2 "${word2}" forms:`, word2Forms);
-
   // Check if any form matches between the two words
   return word1Forms.some(form1 => word2Forms.some(form2 => form1 === form2));
 }

--- a/backend/utils/gameLogic.js
+++ b/backend/utils/gameLogic.js
@@ -56,7 +56,7 @@ function isAnagram(word1, word2) {
 }
 
 // Helper function to check if two words share the same root
-//Since we do not know the part of speech, we check all possible formssing wink-lemmatizer
+//Since we do not know the part of speech, we check all possible forms using wink-lemmatizer
 function sharesSameRoot(word1, word2) {
   // Get all possible lemma forms for both words
   const word1Forms = [

--- a/backend/utils/gameLogic.js
+++ b/backend/utils/gameLogic.js
@@ -1,5 +1,5 @@
 const fs = require('fs');
-
+const lemmatizer = require('wink-lemmatizer');
 // Load dictionary once at startup
 const dictionary = new Set(
   fs
@@ -55,6 +55,29 @@ function isAnagram(word1, word2) {
   return word1.split('').sort().join('') === word2.split('').sort().join('');
 }
 
+// Helper function to check if two words share the same root
+//Since we do not know the part of speech, we check all possible formssing wink-lemmatizer
+function sharesSameRoot(word1, word2) {
+  // Get all possible lemma forms for both words
+  const word1Forms = [
+    lemmatizer.noun(word1.toLowerCase()),
+    lemmatizer.verb(word1.toLowerCase()),
+    lemmatizer.adjective(word1.toLowerCase()),
+  ];
+
+  const word2Forms = [
+    lemmatizer.noun(word2.toLowerCase()),
+    lemmatizer.verb(word2.toLowerCase()),
+    lemmatizer.adjective(word2.toLowerCase()),
+  ];
+
+  console.log(`Word1 "${word1}" forms:`, word1Forms);
+  console.log(`Word2 "${word2}" forms:`, word2Forms);
+
+  // Check if any form matches between the two words
+  return word1Forms.some(form1 => word2Forms.some(form2 => form1 === form2));
+}
+
 function tryToStealWord(word, pot, socketId, gameState) {
   const potLetters = [...pot];
   const wordLetters = word.split('');
@@ -67,7 +90,11 @@ function tryToStealWord(word, pot, socketId, gameState) {
   // Try each existing word to see if it can be used for stealing
   for (const existingWord of allPlayerWords) {
     // Check if this is an exact anagram - if so, skip this word
-    if (isAnagram(existingWord, word) && existingWord !== word) continue;
+    if (
+      (isAnagram(existingWord, word) && existingWord !== word) ||
+      sharesSameRoot(existingWord, word)
+    )
+      continue;
 
     let remainingLetters = [...wordLetters];
     let canUseExistingWord = true;

--- a/frontend/anagrab-frontend/src/App.css
+++ b/frontend/anagrab-frontend/src/App.css
@@ -232,7 +232,9 @@ h3 {
   height: 50px;
   padding: 0 !important;
   border-radius: 50% !important;
-  transition: transform 0.2s, background-color 0.2s;
+  transition:
+    transform 0.2s,
+    background-color 0.2s;
 }
 
 .bag-button:hover {


### PR DESCRIPTION
`Lemmatization -  the process of reducing a word to its root form, or lemma`

Using [wink-lemmatizer](https://github.com/winkjs/wink-lemmatizer) in `gameState.js` a steal move now triggers the new function `sharesSameRoot` which will lemmatize a word in noun, verb, and adjective contexts. If any two lemmas of the original word and new word match, a steal will not go through. 

*Addresses #22, which will close on approval of this PR.